### PR TITLE
Update PostmarkEmailSender.cs

### DIFF
--- a/src/CommunityAbp.Emailing.Postmark/PostmarkEmailSender.cs
+++ b/src/CommunityAbp.Emailing.Postmark/PostmarkEmailSender.cs
@@ -83,7 +83,7 @@ public class PostmarkEmailSender(ISmtpEmailSenderConfiguration smtpConfiguration
         var mailMessage = BuildMailMessage(null, to, subject, body, isBodyHtml, additionalEmailSendingArgs);
 
         // Check if we are sending a templated email
-        if (additionalEmailSendingArgs?.ExtraProperties?.ContainsKey(AbpPostmarkConsts.PostmarkTemplateId) == true)
+        if (additionalEmailSendingArgs?.ExtraProperties?.ContainsKey(AbpPostmarkConsts.PostmarkTemplateId) == true && (AbpPostmarkOptions.UsePostmark ?? false))
         {
             // Safely attempt to retrieve and unbox the PostmarkTemplateId
             var postmarkTemplateIdObj = additionalEmailSendingArgs?.ExtraProperties?.GetOrDefault(AbpPostmarkConsts.PostmarkTemplateId);


### PR DESCRIPTION
minor update to incorporate the appsetting, if postmark is disabled it should fall back to default even if the template exists